### PR TITLE
Functionality of returning the base64 string

### DIFF
--- a/js/xepOnline.jqPlugin.js
+++ b/js/xepOnline.jqPlugin.js
@@ -662,6 +662,9 @@ xepOnline.Formatter = {
 		if(options.render === 'embed') {
 			xepOnline.Formatter.__container.attr('data-xeponline-embed-pending', 'true');
 		}
+		if(options.render === 'base64') {
+			return utf8ToBase64(xepOnline.Formatter.entity_declaration + current_stylesheet + printcopy);
+		}	
 		// fix IE double xmlns declerations in SVG
 		if(xepOnline.IE()) {
 			printcopy = xepOnline.Formatter.cleanSVGDeclarations(printcopy);


### PR DESCRIPTION
I have added another option for getting the base64 for the pdf also. set
render variable at the time of calling to 'base64' and the script would
return base64. Very handy if the pdf is being forwarded to a service
after generation by the developer!